### PR TITLE
Changes for allowing Salus U-mode to create certificate.

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    cdi::{CdiType, CompoundDeviceIdentifier},
+    cdi::{CdiType, CompoundDeviceIdentifier, CDI_ID_LEN},
     x509::{
         certificate::{Certificate, MAX_CERT_SIZE},
         request::CertReq,
@@ -95,5 +95,10 @@ impl<N: ArrayLength<u8>, D: Digest, H: HmacImpl<D>> Layer<N, D, H> {
         let cert_der = Certificate::from_csr(&self.cdi, csr, extns, &mut cert_der_bytes)?;
 
         ArrayVec::try_from(cert_der).map_err(Error::CertificateTooLarge)
+    }
+
+    /// Returns the current layer CDI ID.
+    pub fn cdi_id(&self) -> Result<[u8; CDI_ID_LEN]> {
+        self.cdi.id()
     }
 }


### PR DESCRIPTION
This changed is aimed at creating certificates when a CDI object is somehow remote.

The first change allows CDI ID to be retrieved from a layer.

The second change allows a certificate to be built from a CDI ID and a `impl Signer`.