### PR TITLE
Use trait for CDI. Create a minimal LayerBase type.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ hex = { version = "0.4.3", default-features = false }
 hkdf = "0.12.3"
 hmac = "0.12.1"
 sha2 = {version = "0.10", default-features = false }
+signature = { version = "1.6.4", default-features = false }
 spin = { version = "*", default-features = false, features = ["rwlock"] }
 spki = "0.6.0"
 zeroize = "1.5.7"

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 use crate::Result;
 
+use signature::{Signature, Signer};
 use zeroize::Zeroize;
 
 /// Compound Device Identifier (CDI) Types.
@@ -31,14 +32,14 @@ impl CdiType {
 pub const CDI_ID_LEN: usize = 20;
 
 /// Trait to implement a DICE Compound Device Identifier (CDI)
-pub trait CompoundDeviceIdentifier: Zeroize + Sized {
+pub trait CompoundDeviceIdentifier<const N: usize, S: Signature>:
+    Signer<S> + Zeroize + Sized
+{
     /// Returns the CDI Identifier based on the CDI public key.
     fn id(&self) -> Result<[u8; CDI_ID_LEN]>;
     /// Derives the next layer CDI and keypair for the current CDI, from a TCI
     /// and some additional context information.
     fn next(&self, info: Option<&[u8]>, next_tci: Option<&[u8]>) -> Result<Self>;
-    /// Signs a message with the private key of the current CDI.
-    fn sign(&self, msg: &[u8]) -> [u8; 64];
     /// Returns the public key of the current CDI.
-    fn public_key(&self) -> [u8; 32];
+    fn public_key(&self) -> [u8; N];
 }

--- a/src/cdi.rs
+++ b/src/cdi.rs
@@ -1,16 +1,9 @@
 // SPDX-FileCopyrightText: 2023 Rivos Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+use crate::Result;
 
-use crate::{
-    kdf::{derive_cdi_id, kdf},
-    Error, Result,
-};
-use core::marker::PhantomData;
-use digest::Digest;
-use ed25519_dalek::{Keypair, SecretKey, SECRET_KEY_LENGTH};
-use hkdf::HmacImpl;
-use zeroize::{Zeroize, ZeroizeOnDrop};
+use zeroize::Zeroize;
 
 /// Compound Device Identifier (CDI) Types.
 #[derive(Debug, Copy, Clone)]
@@ -23,7 +16,8 @@ pub enum CdiType {
 }
 
 impl CdiType {
-    fn as_bytes(&self) -> &[u8] {
+    /// Transforms CdiType into a slice.
+    pub fn as_bytes(&self) -> &[u8] {
         match self {
             CdiType::Attestation => b"CDI_Attestation",
             CdiType::Sealing => b"CDI_Sealing",
@@ -31,121 +25,20 @@ impl CdiType {
     }
 }
 
-// From the OpenDice implementation.
-pub(crate) const ID_SALT: [u8; 64] = [
-    0xDB, 0xDB, 0xAE, 0xBC, 0x80, 0x20, 0xDA, 0x9F, 0xF0, 0xDD, 0x5A, 0x24, 0xC8, 0x3A, 0xA5, 0xA5,
-    0x42, 0x86, 0xDF, 0xC2, 0x63, 0x03, 0x1E, 0x32, 0x9B, 0x4D, 0xA1, 0x48, 0x43, 0x06, 0x59, 0xFE,
-    0x62, 0xCD, 0xB5, 0xB7, 0xE1, 0xE0, 0x0F, 0xC6, 0x80, 0x30, 0x67, 0x11, 0xEB, 0x44, 0x4A, 0xF7,
-    0x72, 0x09, 0x35, 0x94, 0x96, 0xFC, 0xFF, 0x1D, 0xB9, 0x52, 0x0B, 0xA5, 0x1C, 0x7B, 0x29, 0xEA,
-];
-
-// From the OpenDice implementation
-pub(crate) const ASYM_SALT: [u8; 64] = [
-    0x63, 0xB6, 0xA0, 0x4D, 0x2C, 0x07, 0x7F, 0xC1, 0x0F, 0x63, 0x9F, 0x21, 0xDA, 0x79, 0x38, 0x44,
-    0x35, 0x6C, 0xC2, 0xB0, 0xB4, 0x41, 0xB3, 0xA7, 0x71, 0x24, 0x03, 0x5C, 0x03, 0xF8, 0xE1, 0xBE,
-    0x60, 0x35, 0xD3, 0x1F, 0x28, 0x28, 0x21, 0xA7, 0x45, 0x0A, 0x02, 0x22, 0x2A, 0xB1, 0xB3, 0xCF,
-    0xF1, 0x67, 0x9B, 0x05, 0xAB, 0x1C, 0xA5, 0xD1, 0xAF, 0xFB, 0x78, 0x9C, 0xCD, 0x2B, 0x0B, 0x3B,
-];
-
 /// The CDI ID length.
 /// The CDI ID is a fixed length derivation of the public key associated
 /// with a CDI.
 pub const CDI_ID_LEN: usize = 20;
 
-/// Extract and expand an asymetric key pair from a CDI.
-fn key_pair_from_cdi<D: Digest, H: HmacImpl<D>>(cdi: &[u8]) -> Result<Keypair> {
-    let mut private_key_bytes = [0u8; SECRET_KEY_LENGTH];
-    kdf::<D, H>(cdi, &ASYM_SALT, &[b"Key_Pair"], &mut private_key_bytes)?;
-    let secret = SecretKey::from_bytes(&private_key_bytes).map_err(Error::InvalidKey)?;
-    Ok(Keypair {
-        public: (&secret).into(),
-        secret,
-    })
-}
-
-/// A DICE Compound Device Identifier (CDI)
-pub struct CompoundDeviceIdentifier<const N: usize, D: Digest, H: HmacImpl<D> = hmac::Hmac<D>> {
-    cdi: [u8; N],
-    cdi_type: CdiType,
-    #[allow(dead_code)]
-    key_pair: Keypair,
-
-    _pd_d: PhantomData<D>,
-    _pd_h: PhantomData<H>,
-}
-
-impl<const N: usize, D: Digest, H: HmacImpl<D>> Zeroize for CompoundDeviceIdentifier<N, D, H> {
-    fn zeroize(&mut self) {
-        self.cdi.zeroize();
-        self.key_pair.to_bytes().zeroize();
-        self._pd_d.zeroize();
-        self._pd_h.zeroize();
-    }
-}
-
-impl<const N: usize, D: Digest, H: HmacImpl<D>> ZeroizeOnDrop
-    for CompoundDeviceIdentifier<N, D, H>
-{
-}
-
-impl<const N: usize, D: Digest, H: HmacImpl<D>> CompoundDeviceIdentifier<N, D, H> {
-    /// DICE CDI constructor.
-    ///
-    /// # Parameters
-    /// @current_cdi: The CDI buffer.
-    /// @cdi_type: The type of CDI
-    pub fn new(cdi_bytes: &[u8], cdi_type: CdiType) -> Result<Self> {
-        let cdi = cdi_bytes.try_into().map_err(Error::InvalidCdi)?;
-        let key_pair = key_pair_from_cdi::<D, H>(cdi_bytes)?;
-
-        Ok(CompoundDeviceIdentifier {
-            cdi,
-            cdi_type,
-            key_pair,
-            _pd_d: PhantomData,
-            _pd_h: PhantomData,
-        })
-    }
-
-    /// Derive the next layer CDI and keypair for the current CDI, from a TCI
+/// Trait to implement a DICE Compound Device Identifier (CDI)
+pub trait CompoundDeviceIdentifier: Zeroize + Sized {
+    /// Returns the CDI Identifier based on the CDI public key.
+    fn id(&self) -> Result<[u8; CDI_ID_LEN]>;
+    /// Derives the next layer CDI and keypair for the current CDI, from a TCI
     /// and some additional context information.
-    ///
-    /// # Parameters
-    ///
-    /// @info is the HKDF expansion additional context information.
-    /// @tci is typically the next layer TCI. If None is passed, the ID_SALT salt is used.
-    pub fn next(&self, info: Option<&[u8]>, next_tci: Option<&[u8]>) -> Result<Self> {
-        let mut next_cdi: [u8; N] = [0; N];
-        kdf::<D, H>(
-            self.cdi.as_slice(),
-            next_tci.unwrap_or(&ID_SALT),
-            &[self.cdi_type.as_bytes(), info.unwrap_or(&[0u8; 0])],
-            next_cdi.as_mut_slice(),
-        )?;
-
-        // Generate the key pair for the next CDI.
-        let next_key_pair = key_pair_from_cdi::<D, H>(next_cdi.as_slice())?;
-
-        Ok(CompoundDeviceIdentifier {
-            cdi: next_cdi,
-            cdi_type: self.cdi_type,
-            key_pair: next_key_pair,
-
-            _pd_d: PhantomData,
-            _pd_h: PhantomData,
-        })
-    }
-
-    /// The ED25519 key pair for the CDI
-    pub fn key_pair(&self) -> &Keypair {
-        &self.key_pair
-    }
-
-    /// CDI Identifier based on the CDI public key.
-    pub fn id(&self) -> Result<[u8; CDI_ID_LEN]> {
-        let mut cdi_id = [0u8; CDI_ID_LEN];
-        derive_cdi_id::<D, H>(self.key_pair.public.as_bytes(), &mut cdi_id)?;
-
-        Ok(cdi_id)
-    }
+    fn next(&self, info: Option<&[u8]>, next_tci: Option<&[u8]>) -> Result<Self>;
+    /// Signs a message with the private key of the current CDI.
+    fn sign(&self, msg: &[u8]) -> [u8; 64];
+    /// Returns the public key of the current CDI.
+    fn public_key(&self) -> [u8; 32];
 }

--- a/src/kdf.rs
+++ b/src/kdf.rs
@@ -5,7 +5,7 @@
 use digest::Digest;
 use hkdf::{Hkdf, HmacImpl};
 
-use crate::{cdi::ID_SALT, Error, Result};
+use crate::{local_cdi::ID_SALT, Error, Result};
 
 // Generic HKDF-based derivation function
 pub(crate) fn kdf<D: Digest, H: HmacImpl<D>>(
@@ -42,8 +42,8 @@ pub fn extract_cdi<D: Digest, H: HmacImpl<D>>(cdi: &[u8], new_cdi: &mut [u8]) ->
 
 #[cfg(test)]
 mod tests {
-    use crate::cdi::ID_SALT;
     use crate::kdf::kdf;
+    use crate::local_cdi::ID_SALT;
 
     type Hmac384 = hmac::Hmac<sha2::Sha384>;
 

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -15,41 +15,34 @@ use arrayvec::ArrayVec;
 use core::marker::PhantomData;
 use digest::Digest;
 use hkdf::HmacImpl;
-use spin::RwLock;
+use spin::{RwLock, RwLockReadGuard};
 use zeroize::{Zeroize, ZeroizeOnDrop};
 
-/// A TCG DICE layer.
-pub struct Layer<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D> = hmac::Hmac<D>> {
-    cdi: C,
-    next_cdi: RwLock<Option<C>>,
-    _pd_d: PhantomData<D>,
-    _pd_h: PhantomData<H>,
+/// A structure representing the basic functionalities of a TCG DICE layer without Certificate handling.
+pub struct LayerBase<Cdi: CompoundDeviceIdentifier> {
+    cdi: Cdi,
+    next_cdi: RwLock<Option<Cdi>>,
 }
 
-impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Zeroize for Layer<C, D, H> {
+impl<C: CompoundDeviceIdentifier> Zeroize for LayerBase<C> {
     fn zeroize(&mut self) {
         self.cdi.zeroize();
         self.next_cdi.write().zeroize();
-        self._pd_d.zeroize();
-        self._pd_h.zeroize();
     }
 }
 
-impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> ZeroizeOnDrop for Layer<C, D, H> {}
+impl<C: CompoundDeviceIdentifier> ZeroizeOnDrop for LayerBase<C> {}
 
-impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Layer<C, D, H> {
+impl<C: CompoundDeviceIdentifier> LayerBase<C> {
     /// DICE layer constructor.
     ///
     /// # Parameters
     /// @cdi: The current layer CDI.
-    /// TODO
-    pub fn new(cdi: C, next_cdi: Option<C>) -> Result<Self> {
-        Ok(Layer {
+    pub const fn new(cdi: C, next_cdi: Option<C>) -> Self {
+        LayerBase {
             cdi,
             next_cdi: RwLock::new(next_cdi),
-            _pd_d: PhantomData,
-            _pd_h: PhantomData,
-        })
+        }
     }
 
     /// Roll the DICE and derive the next layer CDI and keypair from the
@@ -67,6 +60,59 @@ impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Layer<C, D, H> {
         Ok(())
     }
 
+    /// Get a reference to the layer current CDI.
+    pub fn current_cdi(&self) -> &C {
+        &self.cdi
+    }
+
+    /// Get a read lock guard of the optional next CDI.
+    pub fn next_cdi(&self) -> RwLockReadGuard<Option<C>> {
+        self.next_cdi.read()
+    }
+}
+
+/// A TCG DICE layer.
+pub struct Layer<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D> = hmac::Hmac<D>> {
+    base: LayerBase<C>,
+    _pd_d: PhantomData<D>,
+    _pd_h: PhantomData<H>,
+}
+
+impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Zeroize for Layer<C, D, H> {
+    fn zeroize(&mut self) {
+        self.base.zeroize();
+        self._pd_d.zeroize();
+        self._pd_h.zeroize();
+    }
+}
+
+impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> ZeroizeOnDrop for Layer<C, D, H> {}
+
+impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Layer<C, D, H> {
+    /// DICE layer constructor.
+    ///
+    /// # Parameters
+    /// @cdi: The current layer CDI.
+    /// TODO
+    pub const fn new(cdi: C, next_cdi: Option<C>) -> Self {
+        Layer {
+            base: LayerBase::new(cdi, next_cdi),
+            _pd_d: PhantomData,
+            _pd_h: PhantomData,
+        }
+    }
+
+    /// Roll the DICE and derive the next layer CDI and keypair from the
+    /// current CDI.
+    ///
+    /// # Parameters
+    ///
+    /// @info is the HKDF expansion additional context information.
+    /// @tci is the next layer TCI. If None is passed, the ID_SALT salt is used.
+    pub fn roll(&self, info: Option<&[u8]>, next_tci: Option<&[u8]>) -> Result<()> {
+        self.base.roll(info, next_tci)
+    }
+
     /// The certificate DER for the next CDI.
     pub fn next_certificate<'a>(
         &self,
@@ -74,8 +120,8 @@ impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Layer<C, D, H> {
     ) -> Result<ArrayVec<u8, MAX_CERT_SIZE>> {
         let mut cert_der_bytes = [0u8; MAX_CERT_SIZE];
         let cert_der = Certificate::from_layer(
-            &self.cdi,
-            self.next_cdi.read().as_ref().ok_or(Error::MissingNextCdi)?,
+            &self.base.cdi,
+            self.base.next_cdi().as_ref().ok_or(Error::MissingNextCdi)?,
             extns,
             &mut cert_der_bytes,
         )?;
@@ -83,15 +129,19 @@ impl<C: CompoundDeviceIdentifier, D: Digest, H: HmacImpl<D>> Layer<C, D, H> {
         ArrayVec::try_from(cert_der).map_err(Error::CertificateTooLarge)
     }
 
-    /// The certificate DER for the next CDI.
+    /// The certificate DER from a CSR.
     pub fn csr_certificate<'a>(
         &self,
         csr: &'a CertReq<'a>,
         extns: Option<&'a [&'a [u8]]>,
     ) -> Result<ArrayVec<u8, MAX_CERT_SIZE>> {
         let mut cert_der_bytes = [0u8; MAX_CERT_SIZE];
-        let cert_der =
-            Certificate::from_csr::<C, D, H>(&self.cdi, csr, extns, &mut cert_der_bytes)?;
+        let cert_der = Certificate::from_csr::<C, D, H>(
+            self.base.current_cdi(),
+            csr,
+            extns,
+            &mut cert_der_bytes,
+        )?;
 
         ArrayVec::try_from(cert_der).map_err(Error::CertificateTooLarge)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@ pub enum Error {
 /// Custom DICE result.
 pub type Result<T> = core::result::Result<T, Error>;
 
-/// The DICE Compound Device Identifier (CDI) module
+/// The DICE Compound Device Identifier (CDI) interface.
 pub mod cdi;
 
 /// The DICE layer module
@@ -71,3 +71,6 @@ pub mod kdf;
 
 /// X.509 certificate module
 pub mod x509;
+
+/// Local CDI implementation module.
+pub mod local_cdi;

--- a/src/local_cdi.rs
+++ b/src/local_cdi.rs
@@ -133,3 +133,25 @@ impl<const N: usize, D: Digest, H: HmacImpl<D>>
         Ok(cdi_id)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use signature::Signer;
+
+    const CDI_LENGTH: usize = 32;
+
+    #[test]
+    fn local_cdi() {
+        let cdi_bytes = [0u8; CDI_LENGTH];
+        let msg = [1u8; 4096];
+        let cdi =
+            LocalCdi::<CDI_LENGTH, sha2::Sha384>::new(&cdi_bytes, CdiType::Attestation).unwrap();
+
+        assert!(cdi.try_sign(&msg).is_ok());
+        assert_eq!(
+            cdi.sign(&msg).to_bytes().len(),
+            ed25519_dalek::SIGNATURE_LENGTH
+        );
+    }
+}

--- a/src/local_cdi.rs
+++ b/src/local_cdi.rs
@@ -1,0 +1,130 @@
+// Copyright (c) 2022 by Rivos Inc.
+// Licensed under the Apache License, Version 2.0, see LICENSE for details.
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    cdi::{CdiType, CompoundDeviceIdentifier, CDI_ID_LEN},
+    kdf::{derive_cdi_id, kdf},
+    Error, Result,
+};
+use core::marker::PhantomData;
+use digest::Digest;
+use ed25519_dalek::{Keypair, SecretKey, Signer, SECRET_KEY_LENGTH};
+use hkdf::HmacImpl;
+use zeroize::{Zeroize, ZeroizeOnDrop};
+
+// From the OpenDice implementation.
+pub(crate) const ID_SALT: [u8; 64] = [
+    0xDB, 0xDB, 0xAE, 0xBC, 0x80, 0x20, 0xDA, 0x9F, 0xF0, 0xDD, 0x5A, 0x24, 0xC8, 0x3A, 0xA5, 0xA5,
+    0x42, 0x86, 0xDF, 0xC2, 0x63, 0x03, 0x1E, 0x32, 0x9B, 0x4D, 0xA1, 0x48, 0x43, 0x06, 0x59, 0xFE,
+    0x62, 0xCD, 0xB5, 0xB7, 0xE1, 0xE0, 0x0F, 0xC6, 0x80, 0x30, 0x67, 0x11, 0xEB, 0x44, 0x4A, 0xF7,
+    0x72, 0x09, 0x35, 0x94, 0x96, 0xFC, 0xFF, 0x1D, 0xB9, 0x52, 0x0B, 0xA5, 0x1C, 0x7B, 0x29, 0xEA,
+];
+
+// From the OpenDice implementation
+pub(crate) const ASYM_SALT: [u8; 64] = [
+    0x63, 0xB6, 0xA0, 0x4D, 0x2C, 0x07, 0x7F, 0xC1, 0x0F, 0x63, 0x9F, 0x21, 0xDA, 0x79, 0x38, 0x44,
+    0x35, 0x6C, 0xC2, 0xB0, 0xB4, 0x41, 0xB3, 0xA7, 0x71, 0x24, 0x03, 0x5C, 0x03, 0xF8, 0xE1, 0xBE,
+    0x60, 0x35, 0xD3, 0x1F, 0x28, 0x28, 0x21, 0xA7, 0x45, 0x0A, 0x02, 0x22, 0x2A, 0xB1, 0xB3, 0xCF,
+    0xF1, 0x67, 0x9B, 0x05, 0xAB, 0x1C, 0xA5, 0xD1, 0xAF, 0xFB, 0x78, 0x9C, 0xCD, 0x2B, 0x0B, 0x3B,
+];
+
+/// Extract and expand an asymetric key pair from a CDI.
+fn key_pair_from_cdi<D: Digest, H: HmacImpl<D>>(cdi: &[u8]) -> Result<Keypair> {
+    let mut private_key_bytes = [0u8; SECRET_KEY_LENGTH];
+    kdf::<D, H>(cdi, &ASYM_SALT, &[b"Key_Pair"], &mut private_key_bytes)?;
+    let secret = SecretKey::from_bytes(&private_key_bytes).map_err(Error::InvalidKey)?;
+    Ok(Keypair {
+        public: (&secret).into(),
+        secret,
+    })
+}
+
+/// A DICE Compound Device Identifier (CDI) implementation.
+pub struct LocalCdi<const N: usize, D: Digest, H: HmacImpl<D> = hmac::Hmac<D>> {
+    cdi: [u8; N],
+    cdi_type: CdiType,
+    #[allow(dead_code)]
+    key_pair: Keypair,
+
+    _pd_d: PhantomData<D>,
+    _pd_h: PhantomData<H>,
+}
+
+impl<const N: usize, D: Digest, H: HmacImpl<D>> Zeroize for LocalCdi<N, D, H> {
+    fn zeroize(&mut self) {
+        self.cdi.zeroize();
+        self.key_pair.to_bytes().zeroize();
+        self._pd_d.zeroize();
+        self._pd_h.zeroize();
+    }
+}
+
+impl<const N: usize, D: Digest, H: HmacImpl<D>> ZeroizeOnDrop for LocalCdi<N, D, H> {}
+
+impl<const N: usize, D: Digest, H: HmacImpl<D>> LocalCdi<N, D, H> {
+    /// DICE CDI constructor.
+    ///
+    /// # Parameters
+    /// @current_cdi: The CDI buffer.
+    /// @cdi_type: The type of CDI
+    pub fn new(cdi_bytes: &[u8], cdi_type: CdiType) -> Result<Self> {
+        let cdi = cdi_bytes.try_into().map_err(Error::InvalidCdi)?;
+        let key_pair = key_pair_from_cdi::<D, H>(cdi_bytes)?;
+
+        Ok(LocalCdi {
+            cdi,
+            cdi_type,
+            key_pair,
+            _pd_d: PhantomData,
+            _pd_h: PhantomData,
+        })
+    }
+}
+
+impl<const N: usize, D: Digest, H: HmacImpl<D>> CompoundDeviceIdentifier for LocalCdi<N, D, H> {
+    /// Derive the next layer CDI and keypair for the current CDI, from a TCI
+    /// and some additional context information.
+    ///
+    /// # Parameters
+    ///
+    /// @info is the HKDF expansion additional context information.
+    /// @tci is typically the next layer TCI. If None is passed, the ID_SALT salt is used.
+    fn next(&self, info: Option<&[u8]>, next_tci: Option<&[u8]>) -> Result<Self> {
+        let mut next_cdi: [u8; N] = [0; N];
+        kdf::<D, H>(
+            self.cdi.as_slice(),
+            next_tci.unwrap_or(&ID_SALT),
+            &[self.cdi_type.as_bytes(), info.unwrap_or(&[0u8; 0])],
+            next_cdi.as_mut_slice(),
+        )?;
+
+        // Generate the key pair for the next CDI.
+        let next_key_pair = key_pair_from_cdi::<D, H>(next_cdi.as_slice())?;
+
+        Ok(LocalCdi {
+            cdi: next_cdi,
+            cdi_type: self.cdi_type,
+            key_pair: next_key_pair,
+
+            _pd_d: PhantomData,
+            _pd_h: PhantomData,
+        })
+    }
+
+    fn sign(&self, msg: &[u8]) -> [u8; 64] {
+        self.key_pair.sign(msg).to_bytes()
+    }
+
+    fn public_key(&self) -> [u8; 32] {
+        self.key_pair.public.to_bytes()
+    }
+
+    /// CDI Identifier based on the CDI public key.
+    fn id(&self) -> Result<[u8; CDI_ID_LEN]> {
+        let mut cdi_id = [0u8; CDI_ID_LEN];
+        derive_cdi_id::<D, H>(self.key_pair.public.as_bytes(), &mut cdi_id)?;
+
+        Ok(cdi_id)
+    }
+}


### PR DESCRIPTION
To allow a better salus U-mode usage of rice (as dicussed), CDI is separated between implementation and trait.

Also create a `LayerBase` type, that contains basic layer functionalities but has no certificate handling. This is meant to be used in salus, while U-mode will use a full Layer to generate certificates.