### PR TITLE
layer: revert to original form_cdi interface

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -155,14 +155,13 @@ impl<
         extns: Option<&'a [&'a [u8]]>,
     ) -> Result<ArrayVec<u8, MAX_CERT_SIZE>> {
         let mut cert_der_bytes = [0u8; MAX_CERT_SIZE];
-        Certificate::from_layer(
+        let cert_der = Certificate::from_layer(
             &self.base.cdi,
             self.base.next_cdi().as_ref().ok_or(Error::MissingNextCdi)?,
             extns,
             &mut cert_der_bytes,
         )?;
 
-        let cert_der: &[u8] = &cert_der_bytes;
         ArrayVec::try_from(cert_der).map_err(Error::CertificateTooLarge)
     }
 
@@ -173,14 +172,13 @@ impl<
         extns: Option<&'a [&'a [u8]]>,
     ) -> Result<ArrayVec<u8, MAX_CERT_SIZE>> {
         let mut cert_der_bytes = [0u8; MAX_CERT_SIZE];
-        Certificate::from_csr::<N, S, C, D, H>(
+        let cert_der = Certificate::from_csr::<N, S, C, D, H>(
             self.base.current_cdi(),
             csr,
             extns,
             &mut cert_der_bytes,
         )?;
 
-        let cert_der: &[u8] = &cert_der_bytes;
         ArrayVec::try_from(cert_der).map_err(Error::CertificateTooLarge)
     }
 }


### PR DESCRIPTION
After integrating with salus, it turns out having the second slice in simler. The lifetime complexities that motivated the original charge are resolved by attaching the lifetime of the output slice to the input it is based on instead of `Self`.